### PR TITLE
Implement traffic accounting and limiting via an eBPF module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ define Package/uspot
 	   +libblobmsg-json +liblucihttp-ucode +libradcli +libubox +libubus +libuci \
 	   +ratelimit +uspotfilter \
 	   +ucode +ucode-mod-log +ucode-mod-math +ucode-mod-nl80211 +ucode-mod-rtnl +uhttpd-mod-ucode +ucode-mod-uloop \
-	   +kmod-sched-core +kmod-sched-bpf $(BPF_DEPENDS)
+	   +ucode-mod-bpf +ucode-mod-struct +kmod-sched-core +kmod-sched-bpf $(BPF_DEPENDS)
 endef
 
 define Package/uspot/description

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@ PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Thibaut VARÈNE <hacks@slashdirt.org>
 
+PKG_BUILD_DEPENDS:=bpf-headers
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
+include $(INCLUDE_DIR)/bpf.mk
 
 define Package/uspot
   SUBMENU:=Captive Portals
@@ -18,7 +21,8 @@ define Package/uspot
   DEPENDS:=+conntrack \
 	   +libblobmsg-json +liblucihttp-ucode +libradcli +libubox +libubus +libuci \
 	   +ratelimit +uspotfilter \
-	   +ucode +ucode-mod-log +ucode-mod-math +ucode-mod-nl80211 +ucode-mod-rtnl +uhttpd-mod-ucode +ucode-mod-uloop
+	   +ucode +ucode-mod-log +ucode-mod-math +ucode-mod-nl80211 +ucode-mod-rtnl +uhttpd-mod-ucode +ucode-mod-uloop \
+	   +kmod-sched-core +kmod-sched-bpf $(BPF_DEPENDS)
 endef
 
 define Package/uspot/description
@@ -64,11 +68,17 @@ define Package/uspotfilter/description
   It is compatible with firewall4.
 endef
 
+define Build/Compile
+	$(call CompileBPF,$(PKG_BUILD_DIR)/uspot-bpf.c)
+	$(call Build/Compile/Default,)
+endef
+
 define Package/uspot/install
-	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/share $(1)/usr/lib/ucode $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/share $(1)/usr/lib/ucode $(1)/etc/init.d $(1)/etc/config $(1)/lib/bpf
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/radius-client $(1)/usr/bin/radius-client
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/uspot-das $(1)/usr/bin/uspot-das
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/libuam.so $(1)/usr/lib/ucode/uam.so
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/uspot-bpf.o $(1)/lib/bpf/uspot.o
 	$(INSTALL_CONF) ./files/etc/config/uspot $(1)/etc/config/uspot
 	$(INSTALL_BIN) ./files/etc/init.d/uspot $(1)/etc/init.d/uspot
 	$(CP) ./files/usr/bin $(1)/usr/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The software consists of several parts:
 - A client management backend handling client authentication and accounting
 - A firewall wrapper managing client network access and disconnection detection
 - A RADIUS Dynamic Authorization Server for RFC5176 support
+- An eBPF module for high performance traffic accounting
 
 uspot requires OpenWrt 23.05 or newer.
 
@@ -27,7 +28,8 @@ uspot supports 4 authentication modes:
 - `uam` enables RADIUS UAM authentication using a remote web portal
 
 In `radius` and `uam` modes:
-- RADIUS accounting is supported (only 'Session-Time' is reported for now)
+- RADIUS accounting is supported ('Session-Time' and Input/Output Packets/Octets/Gigawords - optionally swapping Input/Output)
+- RADIUS traffic limits are supported (via any combination of the `ChilliSpot-Max-{Input,Output,Total}-{Octets,Gigawords}` attributes)
 
 In `uam` mode:
 - PAP and CHAP passwords are supported
@@ -347,5 +349,4 @@ which means that the probability for such occurrences is expected to be low.
 ## TODO
 
 - UI internationalization (i18n)
-- traffic accounting
 - IPv6 support in uspotfilter

--- a/files/etc/config/uspot
+++ b/files/etc/config/uspot
@@ -30,6 +30,7 @@
 #	option acct_secret ''		# REQUIRED if acct_server is set - radius accounting server password
 #	option acct_proxy ''		# OPTIONAL - radius accounting server proxy
 #	option acct_interval ''		# OPTIONAL - radius accounting interim interval override
+#	option swapio ''		# OPTIONAL - swap the meaning of RADIUS 'Input' and 'Output' attributes
 #	option counters '0'		# OPTIONAL - enable traffic counters (for accounting and/or quota limits)
 #	option das_secret ''		# OPTIONAL - radius DAS secret, enables RADIUS DAS
 #	option das_port '3799'		# OPTIONAL - radius DAS listen port

--- a/files/etc/config/uspot
+++ b/files/etc/config/uspot
@@ -30,6 +30,7 @@
 #	option acct_secret ''		# REQUIRED if acct_server is set - radius accounting server password
 #	option acct_proxy ''		# OPTIONAL - radius accounting server proxy
 #	option acct_interval ''		# OPTIONAL - radius accounting interim interval override
+#	option counters '0'		# OPTIONAL - enable traffic counters (for accounting and/or quota limits)
 #	option das_secret ''		# OPTIONAL - radius DAS secret, enables RADIUS DAS
 #	option das_port '3799'		# OPTIONAL - radius DAS listen port
 #	option nasid ''			# REQUIRED - radius NAS-Identitifer, UAM '&nasid='

--- a/files/etc/radcli/dictionary.chillispot
+++ b/files/etc/radcli/dictionary.chillispot
@@ -9,6 +9,9 @@ ATTRIBUTE	ChilliSpot-Config			6	string	ChilliSpot
 ATTRIBUTE	ChilliSpot-Lang				7	string	ChilliSpot
 ATTRIBUTE	ChilliSpot-Version			8	string	ChilliSpot
 ATTRIBUTE	ChilliSpot-OriginalURL			9	string	ChilliSpot
+ATTRIBUTE	ChilliSpot-Max-Input-Gigawords		21	integer	ChilliSpot
+ATTRIBUTE	ChilliSpot-Max-Output-Gigawords		22	integer	ChilliSpot
+ATTRIBUTE	ChilliSpot-Max-Total-Gigawords		23	integer	ChilliSpot
 ATTRIBUTE	ChilliSpot-UAM-Allowed			100	string ChilliSpot
 ATTRIBUTE	ChilliSpot-MAC-Allowed			101	string ChilliSpot
 ATTRIBUTE	ChilliSpot-Interval			102	integer ChilliSpot

--- a/files/usr/share/uspot/handler-api.uc
+++ b/files/usr/share/uspot/handler-api.uc
@@ -31,6 +31,19 @@ global.handle_request = function(env) {
 			 */
 			if (ctx.seconds_remaining)
 				api['seconds-remaining'] = ctx.seconds_remaining;
+
+			/*
+			 bytes-remaining	number
+			 An integer that indicates the number of bytes remaining, after which the client will be placed
+			 into a captive state. The byte count represents the sum of the total number of IP packet (layer 3)
+			 bytes sent and received by the client, including IP headers. Captive Portal systems might not
+			 count traffic to whitelisted servers, such as the API server, but clients cannot rely on such
+			 behavior. The API server SHOULD include this value if the client is not captive (i.e., captive=false)
+			 and the client session is byte-limited and SHOULD omit this value for captive clients
+			 (i.e., captive=true) or when the session is not byte-limited.
+			 */
+			if (ctx.bytes_remaining)
+				api['bytes-remaining'] = ctx.bytes_remaining;
 		}
 
 		include('templates/api.ut', { api } );

--- a/files/usr/share/uspot/handler-api.uc
+++ b/files/usr/share/uspot/handler-api.uc
@@ -20,8 +20,18 @@ global.handle_request = function(env) {
 		};
 		if (ctx.config.cpa_venue_url)
 			api['venue-info-url'] = ctx.config.cpa_venue_url;
-		if (ctx.seconds_remaining)
-			api['seconds-remaining'] = ctx.seconds_remaining;
+
+		if (!api.captive) {
+			/*
+			 seconds-remaining	number
+			 An integer that indicates the number of seconds remaining, after which the client will be placed
+			 into a captive state. The API server SHOULD include this value if the client is not captive
+			 (i.e., captive=false) and the client session is time-limited and SHOULD omit this value
+			 for captive clients (i.e., captive=true) or when the session is not time-limited.
+			 */
+			if (ctx.seconds_remaining)
+				api['seconds-remaining'] = ctx.seconds_remaining;
+		}
 
 		include('templates/api.ut', { api } );
 	}

--- a/files/usr/share/uspot/portal.uc
+++ b/files/usr/share/uspot/portal.uc
@@ -194,6 +194,7 @@ return {
 
 		ctx.sessionid = cdata.sessionid;
 		ctx.seconds_remaining = cdata.seconds_remaining;
+		ctx.bytes_remaining = cdata.bytes_remaining;
 
 		// split QUERY_STRING
 		if (env.QUERY_STRING) {

--- a/files/usr/share/uspot/uspot.uc
+++ b/files/usr/share/uspot/uspot.uc
@@ -965,6 +965,14 @@ function run_service() {
 						}
 					}
 
+					if (acct_data && (client.maxup || client.maxdown || client.maxtotal)) {
+						// compute a maximum for API bytes-remaining
+						// RFC doesn't distinguish up/down bytes so lets try to come up with something sensible
+						let maxtot = max(client.maxtotal, client.maxup + client.maxdown);
+						let cur = acct_data.bytes_in + acct_data.bytes_out;
+						data.bytes_remaining = maxtot - cur;
+					}
+
 					return data;
 				}
 

--- a/files/usr/share/uspot/uspot.uc
+++ b/files/usr/share/uspot/uspot.uc
@@ -180,11 +180,7 @@ function radius_acct(uspot, mac, payload) {
 		return;
 
 	let client = uspots[uspot].clients[mac];
-	let state = uconn.call('uspotfilter', 'client_get', {
-		interface: uspot,
-		address: mac
-	}) || client;	// fallback to last known state
-	if (!state)
+	if (!client)
 		return;
 
 	payload = radius_init(uspot, mac, payload);
@@ -210,8 +206,8 @@ function radius_acct(uspot, mac, payload) {
 			}
 		}
 	}
-	if (state.data?.radius?.reply?.Class)
-		payload.Class = state.data.radius.reply.Class;
+	if (client.data?.radius?.reply?.Class)
+		payload.Class = client.data.radius.reply.Class;
 
 	radius_call(payload);
 }
@@ -274,12 +270,11 @@ function radius_interim(uspot, mac) {
 
 /**
  * Uspot internal client accounting.
- * This function keeps track of the last known uspotfilter accounting data,
- * and optionally sends interim RADIUS reports if configured
+ * This function optionally sends interim RADIUS reports if configured
  *
  * @param {string} uspot the target uspot
  * @param {string} mac the client MAC address
- * @param {?number} time the UNIX time of the report (only for RADIUS requests)
+ * @param {number} time the UNIX time of the report
  */
 function client_interim(uspot, mac, time) {
 	let client = uspots[uspot].clients[mac];

--- a/files/usr/share/uspot/uspot.uc
+++ b/files/usr/share/uspot/uspot.uc
@@ -274,16 +274,6 @@ function radius_interim(uspot, mac) {
 function client_interim(uspot, mac, time) {
 	let client = uspots[uspot].clients[mac];
 
-	// preserve a copy of last uspotfilter stats for use in disconnect case
-	let state = uconn.call('uspotfilter', 'client_get', {
-		interface: uspot,
-		address: mac
-	});
-	if (!state)
-		return;
-
-	client.acct_data = state.acct_data;
-
 	if (!client.interval)
 		return;
 

--- a/files/usr/share/uspot/uspot.uc
+++ b/files/usr/share/uspot/uspot.uc
@@ -1,7 +1,7 @@
 #!/usr/bin/ucode
 // SPDX-License-Identifier: GPL-2.0-only
 // SPDX-FileCopyrightText: 2022-2023 John Crispin <john@phrozen.org>
-// SPDX-FileCopyrightText: 2023-2024 Thibaut Varène <hacks@slashdirt.org>
+// SPDX-FileCopyrightText: 2023-2025 Thibaut Varène <hacks@slashdirt.org>
 
 'use strict';
 
@@ -13,6 +13,7 @@ let ubus = require('ubus');
 let uconn = ubus.connect();
 let uci = require('uci').cursor();
 let lib = require('uspotlib');
+let uacct;
 import { ulog_open, ulog, ULOG_SYSLOG, LOG_DAEMON, LOG_DEBUG, ERR, WARN, INFO } from 'log';
 
 let uspots = {};
@@ -49,6 +50,7 @@ let uciload = uci.foreach('uspot', 'uspot', (d) => {
 			session_timeout: d.session_timeout || 0,
 			disconnect_delay: d.disconnect_delay,
 			ratelimit_def: d.ratelimit_def,
+			counters: d.counters,
 			debug: d.debug,
 		},
 		clients: {},
@@ -188,13 +190,14 @@ function radius_acct(uspot, mac, payload) {
 
 	if (payload.acct_type != radat_start) {
 		payload['Acct-Session-Time'] = time() - client.connect;
-		if (length(state.acct_data)) {
-			payload['Acct-Output-Octets'] = state.acct_data.bytes_dl & 0xffffffff;
-			payload['Acct-Input-Octets'] = state.acct_data.bytes_ul & 0xffffffff;
-			payload['Acct-Output-Gigawords'] = state.acct_data.bytes_dl >> 32;
-			payload['Acct-Input-Gigawords'] = state.acct_data.bytes_ul >> 32;
-			payload['Acct-Output-Packets'] = state.acct_data.packets_dl;
-			payload['Acct-Input-Packets'] = state.acct_data.packets_ul;
+		let acct_data = +settings.counters ? uacct.client_get(settings.device, mac) : null;
+		if (length(acct_data)) {
+			payload['Acct-Output-Packets'] = acct_data.packets_out;
+			payload['Acct-Output-Octets'] = acct_data.bytes_out & 0xffffffff;
+			payload['Acct-Output-Gigawords'] = acct_data.bytes_out >> 32;
+			payload['Acct-Input-Packets'] = acct_data.packets_in;
+			payload['Acct-Input-Octets'] = acct_data.bytes_in & 0xffffffff;
+			payload['Acct-Input-Gigawords'] = acct_data.bytes_in >> 32;
 		}
 	}
 	if (state.data?.radius?.reply?.Class)
@@ -240,6 +243,8 @@ function radius_start(uspot, mac) {
 		'Acct-Status-Type': radat_start,
 	};
 	debug(uspot, mac + ' acct start');
+	if (+uspots[uspot].settings.counters)
+		uacct.client_add(uspots[uspot].settings.device, mac, true, true);
 	radius_acct(uspot, mac, payload);
 }
 
@@ -465,6 +470,10 @@ function client_remove(uspot, mac, reason) {
 	// delete ratelimit rules if any
 	uconn.call('ratelimit', 'client_delete', { device, address: mac });
 
+	// delete client from traffic accounting map, if any
+	if (uacct)
+		uacct.client_del(device, mac);
+
 	delete uspots[uspot].clients[mac];
 }
 
@@ -579,6 +588,25 @@ function start()
 	for (let uspot, data in uspots) {
 		let server = data.settings.acct_server;
 		let nasid = data.settings.nas_id;
+		let device = data.settings.device;
+
+		// ensure target device is available
+		let count = 10;
+		while (--count && !uconn.call('network.device','status', {name: device})) {
+			WARN(`${uspot}: cannot find device {$device}, retrying: ${count}`);
+			sleep(2000);
+		}
+
+		if (!count) {
+			ERR(`${uspot}: cannot find device {$device}, giving up!`);
+			delete uspots[uspot];
+			continue;
+		}
+
+		if (+data.settings.counters) {
+			uacct = uacct ? uacct : require('uspotbpf');
+			uacct.load(device);
+		}
 
 		if (!server || !nasid)
 			continue;
@@ -599,6 +627,9 @@ function stop()
 	for (let uspot, data in uspots) {
 		if (data.sessionid)	// we have previously sent Accounting-On
 			radius_acctoff(uspot);
+
+		if (+data.settings.counters)
+			uacct.unload(data.settings.device);
 
 		// clear ratelimit rules for our device
 		uconn.call('ratelimit', 'device_delete', { device: data.settings.device });
@@ -857,9 +888,11 @@ function run_service() {
 		client_get: {
 			call: function(req) {
 				function client_get_data(client, uspot, address) {
+					let acct_data = uacct ? uacct.client_get(uspots[uspot].settings.device, address) : null;
 					let data = {
 						... client.data || {},
 						duration: time() - client.connect,
+						... acct_data || {},
 					};
 
 					let timeout = +client.session;

--- a/files/usr/share/uspot/uspot.uc
+++ b/files/usr/share/uspot/uspot.uc
@@ -39,6 +39,7 @@ let uciload = uci.foreach('uspot', 'uspot', (d) => {
 			acct_port: d.acct_port || 1813,
 			acct_proxy: d.acct_proxy,
 			acct_interval: d.acct_interval,
+			swapio: d.swapio,
 			nas_id: d.nasid,
 			nas_mac: d.nasmac,
 			mac_auth: d.mac_auth,
@@ -192,12 +193,21 @@ function radius_acct(uspot, mac, payload) {
 		payload['Acct-Session-Time'] = time() - client.connect;
 		let acct_data = +settings.counters ? uacct.client_get(settings.device, mac) : null;
 		if (length(acct_data)) {
-			payload['Acct-Output-Packets'] = acct_data.packets_out;
-			payload['Acct-Output-Octets'] = acct_data.bytes_out & 0xffffffff;
-			payload['Acct-Output-Gigawords'] = acct_data.bytes_out >> 32;
-			payload['Acct-Input-Packets'] = acct_data.packets_in;
-			payload['Acct-Input-Octets'] = acct_data.bytes_in & 0xffffffff;
-			payload['Acct-Input-Gigawords'] = acct_data.bytes_in >> 32;
+			if (+settings.swapio) {
+				payload['Acct-Output-Packets'] = acct_data.packets_in;
+				payload['Acct-Output-Octets'] = acct_data.bytes_in & 0xffffffff;
+				payload['Acct-Output-Gigawords'] = acct_data.bytes_in >> 32;
+				payload['Acct-Input-Packets'] = acct_data.packets_out;
+				payload['Acct-Input-Octets'] = acct_data.bytes_out & 0xffffffff;
+				payload['Acct-Input-Gigawords'] = acct_data.bytes_out >> 32;
+			} else {
+				payload['Acct-Output-Packets'] = acct_data.packets_out;
+				payload['Acct-Output-Octets'] = acct_data.bytes_out & 0xffffffff;
+				payload['Acct-Output-Gigawords'] = acct_data.bytes_out >> 32;
+				payload['Acct-Input-Packets'] = acct_data.packets_in;
+				payload['Acct-Input-Octets'] = acct_data.bytes_in & 0xffffffff;
+				payload['Acct-Input-Gigawords'] = acct_data.bytes_in >> 32;
+			}
 		}
 	}
 	if (state.data?.radius?.reply?.Class)
@@ -349,6 +359,7 @@ function client_quotalimit(uspot, mac) {
 	let client = uspots[uspot].clients[mac];
 	let device = uspots[uspot].settings.device;
 	let counters = +uspots[uspot].settings.counters;
+	let swapio = +uspots[uspot].settings.swapio;
 
 	if (!(counters && client.radius?.reply))
 		return;
@@ -362,6 +373,12 @@ function client_quotalimit(uspot, mac) {
 
 	if (!(maxdown || maxup || maxtotal))
 		return;
+
+	if (swapio) {
+		let temp = maxdown;
+		maxdown = maxup;
+		maxup = temp;
+	}
 
 	let tx = (!!maxup || !!maxtotal), rx = (!!maxdown || !!maxtotal);
 	if (!length(uacct.client_get(device, mac)))	// don't overide enabled tx/rx counters if radius accounting is on

--- a/files/usr/share/uspot/uspot.uc
+++ b/files/usr/share/uspot/uspot.uc
@@ -667,6 +667,9 @@ function start()
 			uacct.load(device);
 		}
 
+		// clear ratelimit rules for our device
+		uconn.call('ratelimit', 'device_delete', { device: data.settings.device });
+
 		if (!server || !nasid)
 			continue;
 		if ((server in seen) && (nasid in seen[server]))
@@ -675,9 +678,6 @@ function start()
 			seen[server] = {};
 		seen[server][nasid] = 1;
 		radius_accton(uspot);
-
-		// clear ratelimit rules for our device
-		uconn.call('ratelimit', 'device_delete', { device: data.settings.device });
 	}
 }
 

--- a/files/usr/share/uspot/uspot.uc
+++ b/files/usr/share/uspot/uspot.uc
@@ -335,6 +335,46 @@ function client_ratelimit(uspot, mac) {
 }
 
 /**
+ * Apply RADIUS-provided client quota limits.
+ * This function parses a radius reply for the following attributes:
+ * 'ChilliSpot-Max-Total-Octets', 'ChilliSpot-Max-Total-Gigawords'
+ * 'ChilliSpot-Max-Input-Octets', 'ChilliSpot-Max-Input-Gigawords'
+ * 'ChilliSpot-Max-Output-Octets' and/or 'ChilliSpot-Max-Output-Gigawords'
+ * and enforces these limits if present.
+ *
+ * @param {string} uspot the target uspot
+ * @param {string} mac the client MAC address
+ */
+function client_quotalimit(uspot, mac) {
+	let client = uspots[uspot].clients[mac];
+	let device = uspots[uspot].settings.device;
+	let counters = +uspots[uspot].settings.counters;
+
+	if (!(counters && client.radius?.reply))
+		return;
+
+	let reply = client.radius.reply;
+
+	// check known attributes
+	let maxup = (+reply['ChilliSpot-Max-Input-Octets'] + (+reply['ChilliSpot-Max-Input-Gigawords'] << 32)) || 0;
+	let maxdown = (+reply['ChilliSpot-Max-Output-Octets'] + (+reply['ChilliSpot-Max-Output-Gigawords'] << 32)) || 0;
+	let maxtotal = (+reply['ChilliSpot-Max-Total-Octets'] + (+reply['ChilliSpot-Max-Total-Gigawords'] << 32)) || 0;
+
+	if (!(maxdown || maxup || maxtotal))
+		return;
+
+	let tx = (!!maxup || !!maxtotal), rx = (!!maxdown || !!maxtotal);
+	if (!length(uacct.client_get(device, mac)))	// don't overide enabled tx/rx counters if radius accounting is on
+		uacct.client_add(device, mac, tx, rx);
+
+	debug(uspot, mac + " enabling quota limits on " + (tx ? "tx " : "") + (rx ? "rx" : ""));
+
+	client.maxdown = maxdown;
+	client.maxup = maxup;
+	client.maxtotal = maxtotal;
+}
+
+/**
  * Add an authenticated but not yet validated client to the backend.
  * This function adds a client that passed authentication, but hasn't yet been enabled.
  * If the client isn't subsequently enabled, it will be purged after a 60s grace period.
@@ -392,8 +432,6 @@ function client_enable(uspot, mac) {
 	defval = settings.idle_timeout;
 	let idle = +(radius?.reply?.['Idle-Timeout'] || defval);
 
-	let max_total = +(radius?.reply?.['ChilliSpot-Max-Total-Octets'] || 0);
-
 	let cui = radius?.reply?.['Chargeable-User-Identity'];
 
 	let client = {
@@ -402,7 +440,6 @@ function client_enable(uspot, mac) {
 		interval,
 		session,
 		idle,
-		max_total,
 	};
 	if (radius?.request && accounting && interval)
 		client.next_interim = time() + interval;
@@ -415,7 +452,6 @@ function client_enable(uspot, mac) {
 		interface: uspot,
 		address: mac,
 		state: 1,
-		accounting: accounting ? [ "dl", "ul"] : [],
 		data: +uspots[uspot].settings.debug ? client : { connect: client.connect, },
 	});
 
@@ -429,6 +465,9 @@ function client_enable(uspot, mac) {
 
 		// apply ratelimiting rules, if any
 		client_ratelimit(uspot, mac);
+
+		// apply traffic limit/accouting rules, if any
+		client_quotalimit(uspot, mac);
 
 		return true;
 	}
@@ -521,6 +560,8 @@ function accounting(uspot) {
 	let t = time();
 	let accounting = uspots[uspot].settings.accounting;
 	let disconnect_delay = uspots[uspot].settings.disconnect_delay;
+	let device = uspots[uspot].settings.device;
+	let counters = +uspots[uspot].settings.counters;
 
 	if (!list) {
 		WARN(`${uspot} no client list from uspotfilter!`);
@@ -558,11 +599,27 @@ function accounting(uspot) {
 			client_remove(uspot, mac, 'session timeout');
 			continue;
 		}
-		let maxtotal = 0; // +client.max_total;	// XXX currently not implemented
-		if (maxtotal && (((list[mac].acct_data?.bytes_ul || 0) + (list[mac].acct_data?.bytes_dl || 0)) >= maxtotal)) {
-			radius_terminate(uspot, mac, radtc_sessionto);
-			client_remove(uspot, mac, 'max octets reached');
-			continue;
+
+		if (counters) {
+			let maxtotal = client.maxtotal, maxup = client.maxup, maxdown = client.maxdown;
+			if (maxtotal || maxup || maxdown) {
+				let acct_data = uacct.client_get(device, mac);
+				if (maxtotal && ((acct_data?.bytes_in || 0) + (acct_data?.bytes_out || 0)) >= maxtotal) {
+					radius_terminate(uspot, mac, radtc_sessionto);
+					client_remove(uspot, mac, 'max total octets reached');
+					continue;
+				}
+				if (maxup && (acct_data?.bytes_in || 0) >= maxup) {
+					radius_terminate(uspot, mac, radtc_sessionto);
+					client_remove(uspot, mac, 'max ul octets reached');
+					continue;
+				}
+				if (maxdown && (acct_data?.bytes_out || 0) >= maxdown) {
+					radius_terminate(uspot, mac, radtc_sessionto);
+					client_remove(uspot, mac, 'max dl octets reached');
+					continue;
+				}
+			}
 		}
 
 		if (accounting)

--- a/files/usr/share/uspot/uspotbpf.uc
+++ b/files/usr/share/uspot/uspotbpf.uc
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 2025 Thibaut Varène <hacks@slashdirt.org>
+
+/* map contents:
+ struct uspotbpf_cdata {
+	 uint8_t flags;
+	 uint64_t packets_in;
+	 uint64_t bytes_in;
+	 uint64_t packets_out;
+	 uint64_t bytes_out;
+ };
+ */
+
+'use strict';
+
+let bpf = require("bpf");
+import { pack, unpack } from 'struct';
+
+const prio = 0x200;
+const fsbase="/sys/fs/bpf/uspot";
+
+function client_key(mac)
+{
+	let key = map(split(mac, ":"), hex);
+	return pack("6B", ...key);	// network is big endian, string byte order is correct as is
+}
+
+let ctx = {};
+
+function init(devname)
+{
+	/*	XXX doesn't work, progs fail .tc_attach() (and .pin() as well) even though bpf_mod, map and prog are valid
+	let bpf_mod = bpf.open_module("/lib/bpf/uspot.o", {
+		"program-type": {
+			uspotbpf_acct_i: bpf.BPF_PROG_TYPE_SCHED_CLS,
+			uspotbpf_acct_o: bpf.BPF_PROG_TYPE_SCHED_CLS,
+		}
+	});
+	assert(bpf_mod, `Could not load BPF module: ${bpf.error()}`);
+
+	let map = bpf_mod.get_map("m_clients");
+	assert(map, `map open failed: ${bpf.error()}`);
+
+	let prog = {
+		ingress: bpf_mod.get_program("uspotbpf_acct_i"),
+		egress: bpf_mod.get_program("uspotbpf_acct_o"),
+	};
+	assert(prog.ingress && prog.egress, `prog open failed: ${bpf.error()}`);
+	*/
+
+	// XXX REVISIT temporary until the above works
+	let ret = system(["bpftool","prog","loadall","/lib/bpf/uspot.o",`${fsbase}_${devname}`,"pinmaps",`${fsbase}_m_${devname}`]);
+	assert(0 == ret, "bpftool failed to load uspot eBPF module");
+
+	let map = bpf.open_map(`${fsbase}_m_${devname}/m_clients`);
+	assert(map, `map open failed: ${bpf.error()}`);
+
+	let prog = {
+		ingress: bpf.open_program(`${fsbase}_${devname}/uspotbpf_acct_i`),
+		egress: bpf.open_program(`${fsbase}_${devname}/uspotbpf_acct_o`),
+	};
+	assert(prog.ingress && prog.egress, `prog open failed: ${bpf.error()}`);
+
+	ctx[devname] = { prog, map, };
+}
+
+function exit(devname)
+{
+	// XXX REVISIT uneeded if native mod-bpf works
+	system(["rm","-rf",`${fsbase}_${devname}`]);
+	system(["rm","-rf",`${fsbase}_m_${devname}`]);
+	system(["tc","qdisc","del","dev",devname,"clsact"]);
+	delete ctx[devname];
+}
+
+return {
+	load: function(devname)
+	{
+		init(devname);
+		for (let type in ["egress", "ingress"])
+			ctx[devname].prog[type].tc_attach(devname, type, prio);
+	},
+
+	unload: function(devname)
+	{
+		for (let type in ["egress", "ingress"])
+			bpf.tc_detach(devname, type, prio);
+		exit(devname);
+	},
+
+	client_add: function(devname, mac, tx, rx)
+	{
+		let flags = ((tx ? 1 : 0) << 0) | ((rx ? 1 : 0) << 1);
+		if (ctx[devname])
+			ctx[devname].map.set(client_key(mac), pack("BQQQQ", flags, 0, 0, 0, 0));
+	},
+
+	client_del: function(devname, mac)
+	{
+		if (ctx[devname])
+			ctx[devname].map.delete(client_key(mac));
+	},
+
+	client_get: function(devname, mac)
+	{
+		if (!ctx[devname])
+			return {};
+
+		let cdata = ctx[devname].map.get(client_key(mac));
+		if (!cdata)
+			return {};
+
+		cdata = unpack("BQQQQ", cdata);
+		return {
+			packets_in: cdata[1],
+			bytes_in: cdata[2],
+			packets_out: cdata[3],
+			bytes_out: cdata[4],
+		};
+	},
+};

--- a/files/usr/share/uspot/uspotbpf.uc
+++ b/files/usr/share/uspot/uspotbpf.uc
@@ -17,7 +17,6 @@ let bpf = require("bpf");
 import { pack, unpack } from 'struct';
 
 const prio = 0x200;
-const fsbase="/sys/fs/bpf/uspot";
 
 function client_key(mac)
 {
@@ -29,7 +28,6 @@ let ctx = {};
 
 function init(devname)
 {
-	/*	XXX doesn't work, progs fail .tc_attach() (and .pin() as well) even though bpf_mod, map and prog are valid
 	let bpf_mod = bpf.open_module("/lib/bpf/uspot.o", {
 		"program-type": {
 			uspotbpf_acct_i: bpf.BPF_PROG_TYPE_SCHED_CLS,
@@ -46,30 +44,16 @@ function init(devname)
 		egress: bpf_mod.get_program("uspotbpf_acct_o"),
 	};
 	assert(prog.ingress && prog.egress, `prog open failed: ${bpf.error()}`);
-	*/
 
-	// XXX REVISIT temporary until the above works
-	let ret = system(["bpftool","prog","loadall","/lib/bpf/uspot.o",`${fsbase}_${devname}`,"pinmaps",`${fsbase}_m_${devname}`]);
-	assert(0 == ret, "bpftool failed to load uspot eBPF module");
-
-	let map = bpf.open_map(`${fsbase}_m_${devname}/m_clients`);
-	assert(map, `map open failed: ${bpf.error()}`);
-
-	let prog = {
-		ingress: bpf.open_program(`${fsbase}_${devname}/uspotbpf_acct_i`),
-		egress: bpf.open_program(`${fsbase}_${devname}/uspotbpf_acct_o`),
-	};
-	assert(prog.ingress && prog.egress, `prog open failed: ${bpf.error()}`);
-
-	ctx[devname] = { prog, map, };
+	ctx[devname] = { bpf_mod, prog, map, };
+	/* we need to carry a reference to bpf_mod throughout execution to workaround a bug in ucode-mod-bpf:
+	 <nbd> when the reference to the bpf module is dropped, it calls bpf_object__close internally
+	 <nbd> so all program references also become invalid
+	 Fixed in openwrt#e4c3c236b8f15e05b46d23d1771262e75d5b8f81 */
 }
 
 function exit(devname)
 {
-	// XXX REVISIT uneeded if native mod-bpf works
-	system(["rm","-rf",`${fsbase}_${devname}`]);
-	system(["rm","-rf",`${fsbase}_m_${devname}`]);
-	system(["tc","qdisc","del","dev",devname,"clsact"]);
 	delete ctx[devname];
 }
 

--- a/files/usr/share/uspot/uspotbpf.uc
+++ b/files/usr/share/uspot/uspotbpf.uc
@@ -16,7 +16,7 @@
 let bpf = require("bpf");
 import { pack, unpack } from 'struct';
 
-const prio = 0x200;
+const prio = 0x100;	// prio must be higher than that of ratelimit
 
 function client_key(mac)
 {

--- a/files/usr/share/uspotfilter/uspotfilter.uc
+++ b/files/usr/share/uspotfilter/uspotfilter.uc
@@ -254,7 +254,7 @@ function stop()
 }
 
 /*
- "client_set":{"interface":"String","address":"String","id":"String","state":"Integer","dns_state":"Integer","accounting":"Array","data":"Table","flush":"Boolean"}
+ "client_set":{"interface":"String","address":"String","state":"Integer","data":"Table"}
  "client_remove":{"interface":"String","address":"String"}
  "client_get":{"interface":"String","address":"String"}
  "client_list":{"interface":"String"}
@@ -293,19 +293,11 @@ function run_service() {
 			let address = req.args.address;
 			let state = req.args.state || 0;
 			let data = req.args.data;
-			let flush = !!req.args.flush;
 
 			if (!uspot || !address)
 				return ubus.STATUS_INVALID_ARGUMENT;
 			if (!(uspot in uspots))
 				return ubus.STATUS_INVALID_ARGUMENT;
-
-			if (flush) {
-				if (!uspots[uspot].clients[address])
-					return 0;
-				client_remove(uspot, address);
-				return 0;
-			}
 
 			let client = {
 				... uspots[uspot].clients[address] || {},
@@ -328,22 +320,14 @@ function run_service() {
 		 Set client state in a given uspot.
 		 @param interface: REQUIRED: target uspot
 		 @param address: REQUIRED: target client MAC address
-		 @param id: IGNORED
 		 @param state: 1 to allow client, 0 to disallow
-		 @param dns_state: IGNORED
-		 @param accounting: IGNORED
 		 @param data: OPTIONAL client opaque data, stored with client state
-		 @param flush: OPTIONAL true to disallow client and delete associated data
 		 */
 		args: {
 			interface:"",
 			address:"",
-			id:"",
 			state:0,
-			dns_state:0,
-			accounting:[],
 			data:{},
-			flush:false,
 		}
 	},
 	client_remove: {

--- a/src/uspot-bpf.c
+++ b/src/uspot-bpf.c
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 2025 Thibaut Varène <hacks@slashdirt.org>
+
+#include <uapi/linux/bpf.h>
+#include <uapi/linux/if_ether.h>
+#include <uapi/linux/pkt_cls.h>
+#include <asm/rwonce.h>
+#include <bpf/bpf_helpers.h>
+
+#define USPOTBPF_F_ACCT_UL	(1U << 0)
+#define USPOTBPF_F_ACCT_DL	(1U << 1)
+
+struct uspotbpf_cdata {
+	uint8_t flags;
+	uint64_t packets_in;
+	uint64_t bytes_in;
+	uint64_t packets_out;
+	uint64_t bytes_out;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(key_size, ETH_ALEN);
+	__type(value, struct uspotbpf_cdata);
+	__uint(max_entries, 10000);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} m_clients SEC(".maps");
+
+
+static __always_inline void *skb_ptr(struct __sk_buff *skb, __u32 len)
+{
+	void *ptr = (void *)(long)READ_ONCE(skb->data);
+	void *end = (void *)(long)(skb->data_end);
+
+	if (ptr + len >= end)
+		return NULL;
+
+	return ptr;
+}
+
+static __always_inline struct ethhdr *skb_get_ethhdr(struct __sk_buff *skb)
+{
+	struct ethhdr *eth;
+	int len = sizeof(*eth);
+
+	if (len > skb->len)
+		return NULL;
+
+	if (bpf_skb_pull_data(skb, len))
+		return NULL;
+
+	eth = skb_ptr(skb, len);
+	return eth;
+}
+
+
+SEC("tc/ingress")
+int uspotbpf_acct_i(struct __sk_buff *skb)
+{
+	struct uspotbpf_cdata *cdata;
+	struct ethhdr *eth;
+
+	eth = skb_get_ethhdr(skb);
+	if (!eth)
+		goto out;
+
+	cdata = bpf_map_lookup_elem(&m_clients, eth->h_source);
+	if (cdata && (cdata->flags & USPOTBPF_F_ACCT_UL)) {
+		__sync_fetch_and_add(&cdata->packets_in, 1);
+		__sync_fetch_and_add(&cdata->bytes_in, skb->len);
+	}
+out:
+	return TC_ACT_UNSPEC;
+}
+
+SEC("tc/egress")
+int uspotbpf_acct_o(struct __sk_buff *skb)
+{
+	struct uspotbpf_cdata *cdata;
+	struct ethhdr *eth;
+
+	eth = skb_get_ethhdr(skb);
+	if (!eth)
+		goto out;
+
+	cdata = bpf_map_lookup_elem(&m_clients, eth->h_dest);
+	if (cdata && (cdata->flags & USPOTBPF_F_ACCT_DL)) {
+		__sync_fetch_and_add(&cdata->packets_out, 1);
+		__sync_fetch_and_add(&cdata->bytes_out, skb->len);
+	}
+out:
+	return TC_ACT_UNSPEC;
+}
+
+char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
Opening this PR for easy reference until the relevant changes are fully tested and merged

This PR addresses #9 and #25 implementing support for `Acct-{Input,Output}-{Octets,Gigawords,Packets}` attributes in RADIUS reporting and `ChilliSpot-Max-{Input,Output,Total}-{Octets,Gigawords}` for RADIUS-based traffic caps.

@PWJW @badnbusy @nemesifier feel free to chime in with your test results, thanks

Fixes: #9
Fixes: #25