### PR TITLE
Radsec PSK Support

### DIFF
--- a/files/etc/config/uspot
+++ b/files/etc/config/uspot
@@ -21,6 +21,7 @@
 #	option cpa_venue_url ''		# OPTIONAL - value is provided verbatim as 'venue-info-url'
 
 # for auth mode 'uam' and 'radius':
+#	option rad_serv_type 'udp'	# OPTIONAL - radius server type. Supported: udp, tcp
 #	option auth_server ''		# REQUIRED - radius authentication server name or address
 #	option auth_port '1812'		# OPTIONAL - radius authentication server port
 #	option auth_secret ''		# REQUIRED - radius authentication server password

--- a/files/etc/config/uspot
+++ b/files/etc/config/uspot
@@ -21,12 +21,12 @@
 #	option cpa_venue_url ''		# OPTIONAL - value is provided verbatim as 'venue-info-url'
 
 # for auth mode 'uam' and 'radius':
-#	option rad_serv_type 'udp'	# OPTIONAL - radius server type. Supported: udp, tcp
+#	option rad_serv_type 'udp'	# OPTIONAL - radius server type. Supported: udp, tcp, tls, dtls
 #	option auth_server ''		# REQUIRED - radius authentication server name or address
-#	option auth_port '1812'		# OPTIONAL - radius authentication server port
-#	option auth_secret ''		# REQUIRED - radius authentication server password
+#	option auth_port '1812'		# OPTIONAL - radius authentication server port - defaults to 1812 unless rad_serv_type is tls/dtls: 2083
+#	option auth_secret ''		# REQUIRED - radius authentication server password. For tls/dtls with PSK auth, format is 'psk@username@hexkey'
 #	option auth_proxy ''		# OPTIONAL - radius authentication server proxy
-#	option acct_server ''		# REQUIRED if RADIUS accounting is active - radius accounting server name or address
+#	option acct_server ''		# REQUIRED if RADIUS accounting is active and rad_serv_type is not tls/dtls, ignored otherwise - radius accounting server name or address
 #	option acct_port '1813'		# OPTIONAL - radius accounting server port
 #	option acct_secret ''		# REQUIRED if acct_server is set - radius accounting server password
 #	option acct_proxy ''		# OPTIONAL - radius accounting server proxy

--- a/files/usr/share/uspot/uspot.uc
+++ b/files/usr/share/uspot/uspot.uc
@@ -30,6 +30,7 @@ let uciload = uci.foreach('uspot', 'uspot', (d) => {
 		settings: {
 			accounting,
 			device,
+			rad_serv_type: d.rad_serv_type,
 			auth_mode: d.auth_mode,
 			auth_server: d.auth_server,
 			auth_secret: d.auth_secret,
@@ -119,6 +120,9 @@ function json_cmd(cmd, input) {
 function radius_init(uspot, mac, payload, auth) {
 	let settings = uspots[uspot].settings;
 
+	if (settings.rad_serv_type)
+		payload.serv_type = settings.rad_serv_type;
+	
 	if (auth) {
 		payload.server = sprintf('%s:%s:%s', settings.auth_server, settings.auth_port, settings.auth_secret);
 		if (settings.auth_proxy)

--- a/files/usr/share/uspot/uspot.uc
+++ b/files/usr/share/uspot/uspot.uc
@@ -25,16 +25,19 @@ let uciload = uci.foreach('uspot', 'uspot', (d) => {
 	if (!d[".anonymous"]) {
 		let accounting = !!(d.acct_server && d.acct_secret);
 		let device = uci.get('network', d.interface, 'device');
+		let radsec = !!(d.rad_serv_type in ["tls", "dtls"]);
+
 		uspots[d[".name"]] = {
 		state: 1,	// active by default
 		settings: {
 			accounting,
 			device,
+			radsec,
 			rad_serv_type: d.rad_serv_type,
 			auth_mode: d.auth_mode,
 			auth_server: d.auth_server,
 			auth_secret: d.auth_secret,
-			auth_port: d.auth_port || 1812,
+			auth_port: d.auth_port || ((radsec) ? 2083 : 1812),
 			auth_proxy: d.auth_proxy,
 			acct_server: d.acct_server,
 			acct_secret: d.acct_secret,
@@ -122,17 +125,18 @@ function radius_init(uspot, mac, payload, auth) {
 
 	if (settings.rad_serv_type)
 		payload.serv_type = settings.rad_serv_type;
-	
-	if (auth) {
-		payload.server = sprintf('%s:%s:%s', settings.auth_server, settings.auth_port, settings.auth_secret);
-		if (settings.auth_proxy)
-			payload.auth_proxy = settings.auth_proxy;
-	}
-	else {
-		payload.acct = true;
+
+	payload.acct = !auth;
+
+	if (!(auth || settings.radsec)) {	// acct_server is not used in RadSec
 		payload.acct_server = sprintf('%s:%s:%s', settings.acct_server, settings.acct_port, settings.acct_secret);
 		if (settings.acct_proxy)
 			payload.acct_proxy = settings.acct_proxy;
+	}
+	else {
+		payload.server = sprintf('%s:%s:%s', settings.auth_server, settings.auth_port, settings.auth_secret);
+		if (settings.auth_proxy)
+			payload.auth_proxy = settings.auth_proxy;
 	}
 
 	payload['NAS-Identifier'] = settings.nas_id;	// XXX RFC says NAS-IP is not required when NAS-ID is set, but it's added by libradcli anyway

--- a/src/radius-client.c
+++ b/src/radius-client.c
@@ -31,6 +31,7 @@ enum {
 	RADIUS_acct,
 	RADIUS_authserver,
 	RADIUS_acctserver,
+	RADIUS_servtype,
 	RADIUS_ACCT_TYPE,
 	RADIUS_USERNAME,
 	RADIUS_PASSWORD,
@@ -67,6 +68,7 @@ static struct blobmsg_policy radius_policy[__RADIUS_MAX] = {
 	[RADIUS_acct] = { .name = "acct", .type = BLOBMSG_TYPE_BOOL },
 	[RADIUS_authserver] = { .name = "server", .type = BLOBMSG_TYPE_STRING },
 	[RADIUS_acctserver] = { .name = "acct_server", .type = BLOBMSG_TYPE_STRING },
+	[RADIUS_servtype] = { .name = "serv_type", .type = BLOBMSG_TYPE_STRING },
 	[RADIUS_PROXY_STATE_AUTH] = { .name = "auth_proxy", .type = BLOBMSG_TYPE_STRING },
 	[RADIUS_PROXY_STATE_ACCT] = { .name = "acct_proxy", .type = BLOBMSG_TYPE_STRING },
 };
@@ -229,6 +231,7 @@ static int nonattr_blobkey(int key)
 		case RADIUS_acct:
 		case RADIUS_authserver:
 		case RADIUS_acctserver:
+		case RADIUS_servtype:
 		// override proxy
 		case RADIUS_PROXY_STATE_ACCT:
 		case RADIUS_PROXY_STATE_AUTH:
@@ -257,6 +260,12 @@ radius(rc_handle *rh)
 	if (tb[RADIUS_acctserver]) {
 		if (rc_add_config(rh, "acctserver", blobmsg_get_string(tb[RADIUS_acctserver]), "code", __LINE__)) {
 			ULOG_ERR("Failed to set acctserver!\n");
+			goto fail;
+		}
+	}
+	if (tb[RADIUS_servtype]) {
+		if (rc_add_config(rh, "serv-type", blobmsg_get_string(tb[RADIUS_servtype]), "code", __LINE__)) {
+			ULOG_ERR("Failed to set serv-type!\n");
 			goto fail;
 		}
 	}


### PR DESCRIPTION
Up for testing. As a side effect this introduces the ability to use TCP for RADIUS connections.

Enabling should be a simple matter of setting `rad_serv_type` to either `tls` or `dtls` where applicable, and setting `auth_secret` in the form of `psk@username@hexkey` where 'username' and 'hexkey' must be adjusted, as required by libradcli.

This also needs a custom built libradcli package with support for TLS, which was fixed in https://github.com/openwrt/packages/pull/26765

Fixes: #26 