### PR TITLE
CMakeLists: set minimum required version to 3.10 for cmake 4.x compat…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 PROJECT(uspot C)
 INCLUDE(GNUInstallDirs)


### PR DESCRIPTION
…ibility

Fixes:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```

Follow-up of https://github.com/f00b4r0/uspot/pull/51